### PR TITLE
Adicionando suporte para conexão com o banco de dados MySQL usando Docker Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
+#Mudança para docker compose
 DB_CONNECTION=mysql
 DB_HOST=mysql
 DB_PORT=3306

--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,15 @@
 APP_NAME=Laravel
 APP_ENV=local
-APP_KEY=
+APP_KEY=base64:GLRHofBglDsGCNXfAYnwImCmskcsmm/JwxstLHuFAAY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://localhost:8080
 
 LOG_CHANNEL=stack
 LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 DB_CONNECTION=mysql
-DB_HOST=127.0.0.1
+DB_HOST=mysql
 DB_PORT=3306
 DB_DATABASE=laravel
 DB_USERNAME=root

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 APP_NAME=Laravel
 APP_ENV=local
-APP_KEY=base64:GLRHofBglDsGCNXfAYnwImCmskcsmm/JwxstLHuFAAY=
+APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost:8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,5 @@ RUN chown -R www-data:www-data storage
 # Habilita o módulo rewrite do Apache
 RUN a2enmod rewrite
 
-# Expõe a porta 80
+# Expõe a porta 80, se necessário mudar
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 # Imagem base
 FROM php:8.1-apache
 
-# Argumento de ambiente
-ARG environment='teste'
-
 # Atualiza repositórios, instala dependências e limpa pacotes baixados
 RUN apt-get update \
     && apt-get -y install curl git zip zlib1g-dev libzip-dev \
@@ -12,61 +9,38 @@ RUN apt-get update \
 # Instala extensões PHP necessárias
 RUN docker-php-ext-install mysqli pdo_mysql zip
 
-# Instala o MySQL
-RUN apt-get update \
-    && apt-get -y install default-mysql-client
-
 # Variável de ambiente para o diretório raiz do Apache
 ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
 
 # Atualiza configurações do Apache para usar o diretório raiz especificado
-RUN find /etc/apache2 -type f -exec sed -i 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' {} +
+RUN find /etc/apache2 -type f -exec sed -i "s!/var/www/html!${APACHE_DOCUMENT_ROOT}!g" {} +
 
 # Volume para armazenar logs fora do contêiner
 VOLUME ["/var/www/html/storage/logs"]
-
-# Instala o Composer
-RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" \
-    && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
-    && rm composer-setup.php
-
-# Define permissão para o Composer ser executado como superusuário
-ENV COMPOSER_ALLOW_SUPERUSER 1
-
-# Ativa módulos SSL e Rewrite do Apache
-RUN a2enmod ssl && a2enmod rewrite
-
-# Renomeia arquivo de configuração do PHP para produção
-RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
-
-# Aumenta o limite de memória, tamanho de post e upload do PHP
-RUN echo 'memory_limit=1024M' >> /usr/local/etc/php/conf.d/docker-php-memory-limit.ini \
-    && echo 'post_max_size=256M' >> /usr/local/etc/php/conf.d/docker-php-post-limit.ini \
-    && echo 'upload_max_size=256M' >> /usr/local/etc/php/conf.d/docker-php-upload-limit.ini
 
 # Define o diretório de trabalho
 WORKDIR /var/www/html
 
 # Copia os arquivos do aplicativo
-COPY . /var/www/html/.
+COPY . .
+
+# Copia o composer.json, o composer.lock e instala as dependências do Composer
+COPY composer.json composer.lock ./
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN composer install --optimize-autoloader --no-scripts
+
+# Executa os comandos Artisan e ajustes de permissões
+RUN php artisan cache:clear
+RUN php artisan config:cache
+RUN php artisan route:cache
+RUN php artisan key:generate
 
 # Define permissões de escrita para o diretório de armazenamento
-RUN chmod o+w ./storage/ -R
+RUN chmod 777 -R storage
+RUN chown -R www-data:www-data storage
 
-# Instala dependências do Composer
-RUN composer install
-
-# Executa comandos Artisan e ajustes de permissões
-RUN php artisan cache:clear \
-    && php artisan config:cache \
-    && php artisan route:cache \
-    && php artisan key:generate \
-    && chmod 777 -R /var/www/html/storage/ \
-    && chown -R www-data:www-data /var/www/ \
-    && a2enmod rewrite
+# Habilita o módulo rewrite do Apache
+RUN a2enmod rewrite
 
 # Expõe a porta 80
 EXPOSE 80
-
-#If necessary
-#EXPOSE 443

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+#adicionando docker compose
 version: "3"
 services:
   minnemi-back-app:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-#adicionando docker compose
 version: "3"
 services:
   minnemi-back-app:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "3"
+services:
+  minnemi-back-app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/var/www/html
+    ports:
+      - 8080:80
+    depends_on:
+      - mysql
+
+  mysql:
+    image: mysql:latest
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+      MYSQL_DATABASE: ${DB_DATABASE}
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
Nesta solicitação de pull, adicionamos suporte para conexão com o banco de dados MySQL usando o Docker Compose. Anteriormente, o projeto estava enfrentando problemas de conexão entre o aplicativo Laravel e o servidor MySQL, resultando no erro "SQLSTATE[HY000] [2002] Connection refused".

Alterações propostas:

Introdução do Docker Compose: Implementamos o uso do Docker Compose para simplificar a configuração e execução do ambiente de desenvolvimento. Isso inclui a definição dos serviços necessários para o aplicativo Laravel, como o serviço do PHP com o Apache e o serviço do MySQL.

Criação de rede personalizada: Utilizamos o Docker Compose para criar automaticamente uma rede personalizada, permitindo que os contêineres do PHP e do MySQL se comuniquem.

Atualização do arquivo docker-compose.yml: No arquivo docker-compose.yml, adicionamos os serviços necessários, definimos volumes, portas e dependências para garantir a execução correta dos contêineres.

Atualização do arquivo .env: Fizemos ajustes no arquivo .env para garantir que as configurações de conexão com o banco de dados estejam corretas, incluindo o nome do host, porta, nome do banco de dados, nome de usuário e senha.

Essas alterações solucionaram o problema de conexão com o banco de dados e permitiram a execução do comando migrate:status com sucesso, exibindo os status corretos das migrações.

Por favor, revise e aprove a solicitação de pull. Estou à disposição para esclarecer qualquer dúvida ou realizar ajustes adicionais, se necessário.